### PR TITLE
do not set HAVE_HASH_BANG_EXEC to enable alternative path that supports hashbang on shell scripts

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -18,5 +18,5 @@ zopen_check_results()
   # Echo the following information to guage build health
   echo "actualFailures:$failures"
   echo "totalTests:$total"
-  echo "expectedFailures:16"
+  echo "expectedFailures:12"
 }

--- a/patches/PR1.patch
+++ b/patches/PR1.patch
@@ -1458,18 +1458,6 @@ index 32b4c7c..caa4f1b 100644
  #    include <sys/param.h>
  #  endif
  #  include <time.h>
-diff --git a/configure b/configure
-index 4731375..fef576d 100755
---- a/configure
-+++ b/configure
-@@ -3281,6 +3281,7 @@ m68k-sysv)	opt_bash_malloc=no ;;	# fixes file descriptor leak in closedir
- *-beos*)	opt_bash_malloc=no ;;	# they say it's suitable
- # These need additional investigation
- sparc-linux*)	opt_bash_malloc=no ;;	# sparc running linux; requires ELF
-+i370-*)		opt_bash_malloc=no ;;	# z/OS machines
- *-aix*)		opt_bash_malloc=no ;;	# AIX machines
- *-cygwin*)	opt_bash_malloc=no ;;	# Cygnus's CYGWIN environment
- # These lack a working sbrk(2)
 diff --git a/shell.c b/shell.c
 index ee9d445..d9b1c50 100644
 --- a/shell.c
@@ -1483,3 +1471,25 @@ index ee9d445..d9b1c50 100644
    char **env;
  
    env = environ;
+diff --git a/configure b/configure
+index 4731375..cd52c35 100755
+--- a/configure
++++ b/configure
+@@ -3281,6 +3281,7 @@ m68k-sysv)	opt_bash_malloc=no ;;	# fixes file descriptor leak in closedir
+ *-beos*)	opt_bash_malloc=no ;;	# they say it's suitable
+ # These need additional investigation
+ sparc-linux*)	opt_bash_malloc=no ;;	# sparc running linux; requires ELF
++i370-*)		opt_bash_malloc=no ;;	# z/OS machines
+ *-aix*)		opt_bash_malloc=no ;;	# AIX machines
+ *-cygwin*)	opt_bash_malloc=no ;;	# Cygnus's CYGWIN environment
+ # These lack a working sbrk(2)
+@@ -18058,7 +18059,8 @@ fi
+ printf "%s\n" "$ac_cv_sys_interpreter" >&6; }
+ interpval=$ac_cv_sys_interpreter
+ 
+-if test $ac_cv_sys_interpreter = yes; then
++# z/OS (openedition) does not support hashbang on shell scripts
++if test $ac_cv_sys_interpreter = yes -a test "$host_os" != "openedition" ; then
+ printf "%s\n" "#define HAVE_HASH_BANG_EXEC 1" >>confdefs.h
+ 
+ fi


### PR DESCRIPTION
Resolves https://github.com/ZOSOpenTools/bashport/issues/33

Test status after change:
VERBOSE: 'Test results: 65 tests pass out of 77 tests - 84.42% success rate'
