### PR TITLE
Provide clean sigaction object for call to sigaction()

### DIFF
--- a/patches/sig.c.patch
+++ b/patches/sig.c.patch
@@ -1,0 +1,22 @@
+diff --git a/sig.c b/sig.c
+index 840d577..8e871c1 100644
+--- a/sig.c
++++ b/sig.c
+@@ -349,8 +349,6 @@ reset_terminating_signals ()
+     return;
+ 
+ #if defined (HAVE_POSIX_SIGNALS)
+-  act.sa_flags = 0;
+-  sigemptyset (&act.sa_mask);
+   for (i = 0; i < TERMSIGS_LENGTH; i++)
+     {
+       /* Skip a signal if it's trapped or handled specially, because the
+@@ -358,6 +356,8 @@ reset_terminating_signals ()
+       if (signal_is_trapped (XSIG (i)) || signal_is_special (XSIG (i)))
+ 	continue;
+ 
++  act.sa_flags = 0;
++  sigemptyset (&act.sa_mask);
+       act.sa_handler = XHANDLER (i);
+       act.sa_flags = XSAFLAGS (i);
+       sigaction (XSIG (i), &act, (struct sigaction *) NULL);


### PR DESCRIPTION
See if the sigaction object is being 'dirtied' by the sigaction call, in which case, providing a 'clean' one on each iteration would fix the protection exception (specifically thinking it might be getting garbage from the mask and therefore looking into the wrong function pointer based on the mask?

So establish the sigaction object before each call to see if this eliminates the protection exception. If this doesn't fix it, maybe it is an OPT bug?

@IgorTodorovskiIBM curious if you have other ideas. It is getting a protection exception on line 363, which is the sigaction call (last line) of the patch. Since it doesn't blow up for me in my sandbox, all I know is it didn't get worse 😩 