### PR TITLE
Workaround for external link

### DIFF
--- a/patches/findcmd.c.patch
+++ b/patches/findcmd.c.patch
@@ -1,16 +1,18 @@
 diff --git a/findcmd.c b/findcmd.c
-index da6ac53..069848b 100644
+index 95f231e..278dbb9 100644
 --- a/findcmd.c
 +++ b/findcmd.c
-@@ -121,7 +121,10 @@ file_status (name)
+@@ -119,8 +119,11 @@ file_status (name)
+   int r;
+ 
    /* Determine whether this file exists or not. */
-   if (stat (name, &finfo) < 0) {
- #ifdef __MVS__
--    if (!(__errno2() == 93586002 /* External Link */ && lstat(name, &finfo) == 0))
-+    /* Workaround for z/OS not supporting stat on external links
-+       Run bpxmtext 05940252 to get more info */
-+    if (!(__errno2() == 0x05940252 /* JRExternalLink */ && 
-+        lstat(name, &finfo) == 0))
- #endif
-     return (0);
-   }
+-  if (stat (name, &finfo) < 0)
+-    return (0);
++  if (stat (name, &finfo) < 0) {
++    /* Workaround for z/OS not supporting stat on external links */
++    if (!(lstat(name, &finfo) == 0) && S_ISEXTL(finfo.st_mode,finfo.st_genvalue)) 
++      return (0);
++  }
+ 
+   /* If the file is a directory, then it is not "executable" in the
+      sense of the shell. */

--- a/patches/findcmd.c.patch
+++ b/patches/findcmd.c.patch
@@ -1,18 +1,16 @@
 diff --git a/findcmd.c b/findcmd.c
-index 95f231e..da6ac53 100644
+index da6ac53..069848b 100644
 --- a/findcmd.c
 +++ b/findcmd.c
-@@ -119,8 +119,12 @@ file_status (name)
-   int r;
- 
+@@ -121,7 +121,10 @@ file_status (name)
    /* Determine whether this file exists or not. */
--  if (stat (name, &finfo) < 0)
-+  if (stat (name, &finfo) < 0) {
-+#ifdef __MVS__
-+    if (!(__errno2() == 93586002 /* External Link */ && lstat(name, &finfo) == 0))
-+#endif
+   if (stat (name, &finfo) < 0) {
+ #ifdef __MVS__
+-    if (!(__errno2() == 93586002 /* External Link */ && lstat(name, &finfo) == 0))
++    /* Workaround for z/OS not supporting stat on external links
++       Run bpxmtext 05940252 to get more info */
++    if (!(__errno2() == 0x05940252 /* JRExternalLink */ && 
++        lstat(name, &finfo) == 0))
+ #endif
      return (0);
-+  }
- 
-   /* If the file is a directory, then it is not "executable" in the
-      sense of the shell. */
+   }

--- a/patches/findcmd.c.patch
+++ b/patches/findcmd.c.patch
@@ -1,0 +1,18 @@
+diff --git a/findcmd.c b/findcmd.c
+index 95f231e..da6ac53 100644
+--- a/findcmd.c
++++ b/findcmd.c
+@@ -119,8 +119,12 @@ file_status (name)
+   int r;
+ 
+   /* Determine whether this file exists or not. */
+-  if (stat (name, &finfo) < 0)
++  if (stat (name, &finfo) < 0) {
++#ifdef __MVS__
++    if (!(__errno2() == 93586002 /* External Link */ && lstat(name, &finfo) == 0))
++#endif
+     return (0);
++  }
+ 
+   /* If the file is a directory, then it is not "executable" in the
+      sense of the shell. */


### PR DESCRIPTION
External links currently cannot be executed.

Leverages the 93586002 errno2 code that states that the file is an external link and uses lstat to get the properties.

One example is ping:
```
[ITODORO@ZOSCAN2B ~/projects/bashport_new/bash-5.2]$ ping
bash: ping: command not found
```

With the change:
```
[ITODORO@ZOSCAN2B ~/projects/bashport_new/bash-5.2]$ ping google.com
CS V2R4: Pinging host google.com (142.251.163.113)
Ping #1 response took 0.013 seconds.
```