### PR TITLE
allow ssh non-interactive login to source bashrc

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -8,7 +8,7 @@ export ZOPEN_DEV_URL="https://github.com/bminor/bash.git"
 export ZOPEN_DEV_DEPS="perl m4 autoconf curl gzip tar make zoslib coreutils diffutils sed ncurses bison grep"
 export ZOPEN_DEV_BRANCH="devel"
 
-export ZOPEN_EXTRA_CPPFLAGS="-DNO_MAIN_ENV_ARG=1"
+export ZOPEN_EXTRA_CPPFLAGS="-DNO_MAIN_ENV_ARG=1 -DSSH_SOURCE_BASHRC=1"
 export ZOPEN_COMP=CLANG
 
 zopen_post_buildenv()


### PR DESCRIPTION
* Addresses https://github.com/ZOSOpenTools/bashport/issues/65
* This will match the Rocket bash behaviour, as well as many other platforms, include Mac.
* Brew is also adding this flag: https://github.com/Homebrew/homebrew-core/blob/8e59f8db5505f873483790c2eb3163f9d9a082f5/Formula/b/bash.rb#L100-L106
```
    # When built with SSH_SOURCE_BASHRC, bash will source ~/.bashrc when
    # it's non-interactively from sshd.  This allows the user to set
    # environment variables prior to running the command (e.g. PATH).  The
    # /bin/bash that ships with macOS defines this, and without it, some
    # things (e.g. git+ssh) will break if the user sets their default shell to
    # Homebrew's bash instead of /bin/bash.
    ENV.append_to_cflags "-DSSH_SOURCE_BASHRC"
```
* My ubuntu machine also seems to have this enabled. 

**New behaviour:**
```
ssh -i~/.ssh/id_rsa_jenkins itodoro@128.168.129.26 "ls"
<sources .bashrc>
<lists my files>
```

**Previous behaviour:**
```
ssh -i~/.ssh/id_rsa_jenkins itodoro@128.168.129.26 "ls"
<does not SOURCE .bashrc>
<lists my files>

```