### PR TITLE
Define SYS_BASHRC and NON_INTERACTIVE_LOGIN_SHELLS

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -8,7 +8,7 @@ export ZOPEN_DEV_URL="https://github.com/bminor/bash.git"
 export ZOPEN_DEV_DEPS="perl m4 autoconf curl gzip tar make zoslib coreutils diffutils sed ncurses bison grep"
 export ZOPEN_DEV_BRANCH="devel"
 
-export ZOPEN_EXTRA_CPPFLAGS="-DNO_MAIN_ENV_ARG=1 -DSSH_SOURCE_BASHRC=1"
+export ZOPEN_EXTRA_CPPFLAGS="-DNO_MAIN_ENV_ARG=1 -DSSH_SOURCE_BASHRC=1 -DSYS_BASHRC='\\\"/etc/bashrc\\\"' -DNON_INTERACTIVE_LOGIN_SHELLS=1"
 export ZOPEN_COMP=CLANG
 
 zopen_post_buildenv()


### PR DESCRIPTION
* On Linux builds, SYS_BASHRC and NON_INTERACTIVE_LOGIN_SHELLS are set. 

SYS_BASHRC will instruct bash to check for /etc/bashrc and source it